### PR TITLE
Add link to 'init.state' in pomp.Rd

### DIFF
--- a/man/pomp.Rd
+++ b/man/pomp.Rd
@@ -141,6 +141,7 @@
       \item as a snippet of C code (via \code{\link{Csnippet}}).
       See the \code{\link{Csnippet}} help for rules on writing a custom initializer.
     }
+    It can be accessed via \code{\link{init.state}}.
   }
   \item{rprior}{
     optional; function drawing a sample from a prior distribution on parameters.


### PR DESCRIPTION
Aaron-- just a suggestion. Keep or ignore depending on whether you think it adds enough to compensate potential user distraction.
