### PR TITLE
Make output observation values consistent with stochastic simulation state

### DIFF
--- a/src/ssa.c
+++ b/src/ssa.c
@@ -164,8 +164,11 @@ static void SSA (pomp_ssa_rate_fn *ratefun, int irep,
     while ((icount < ntimes) && (t >= times[icount])) {
       for (i = 0; i < nvar; i++)
         xout[i+nvar*(irep+nrep*icount)] = ylast[i];
-      // Set appropriate states to zero
-      for (i = 0; i < nzero; i++) y[izero[i]] =0.0;
+      // Set appropriate states to zero at time of last observation
+      for (i = 0; i < nzero; i++) {
+	y[izero[i]] -= ylast[izero[i]];
+	ylast[izero[i]] = 0;
+      }
       // Recompute if zero event-rate encountered
       if (flag) t = times[icount];
       icount++;

--- a/src/ssa.c
+++ b/src/ssa.c
@@ -116,7 +116,7 @@ static void SSA (pomp_ssa_rate_fn *ratefun, int irep,
   double tmax = times[ntimes-1];
   double *covars = NULL;
   double *f = NULL;
-  double par[npar], y[nvar];
+  double par[npar], y[nvar], ylast[nvar];
   struct lookup_table tab = {lcov, mcov, 0, tcov, cov};
   int i, j;
 
@@ -140,6 +140,7 @@ static void SSA (pomp_ssa_rate_fn *ratefun, int irep,
   int icount = 1;
   while (icount < ntimes) {
     R_CheckUserInterrupt();
+    memcpy(ylast, y, nvar * sizeof(double));
     if (method == 0) {	// Gillespie's next reaction method
       flag = gillespie(ratefun,&t,f,y,v,d,par,nvar,nevent,npar,istate,ipar,ncovar,icovar,mcov,covars);
     } else {	 // Cai's K-leap method
@@ -162,7 +163,7 @@ static void SSA (pomp_ssa_rate_fn *ratefun, int irep,
     // Record output at required time points
     while ((icount < ntimes) && (t >= times[icount])) {
       for (i = 0; i < nvar; i++)
-        xout[i+nvar*(irep+nrep*icount)] = y[i];
+        xout[i+nvar*(irep+nrep*icount)] = ylast[i];
       // Set appropriate states to zero
       for (i = 0; i < nzero; i++) y[izero[i]] =0.0;
       // Recompute if zero event-rate encountered


### PR DESCRIPTION
I made these changes to address a problem that can be reproduced with this code:

```r
create_example <- function(times = 1, t0 = 0, params = c(mu = 0.001, N_0 = 1)) {
  data <- data.frame(time = times, reports = NA)
  d <- cbind(death = c(1))
  v <- cbind(death = c(-1))
  f <- function(j, x, t, params, ...){
    params["mu"] * x[1]
  }
  rprocess <- pomp::gillespie.sim(rate.fun = f, v = v, d = d)
  initializer <- function(params, t0, ...) {
    comp.names <- c("N")
    ic.names <- c("N_0")
    x0 <- stats::setNames(numeric(1), c("N"))
    x0["N"] <- params["N_0"]
    x0
  }
  pomp::pomp(data = data, times = "time", t0 = t0, params = params,
             rprocess = rprocess, statenames = c("N"),
             paramnames = c("mu", "N_0"),
             initializer = initializer)
}

ex <- create_example()
pomp::simulate(ex, as.data.frame=TRUE, states=TRUE, times = c(0, 1, 1e6), nsim = 100)
```

This code is supposed to simulate a death process that starts with a singe individual at time zero with a death rate of 0.001. Thus the expected behavior is that at time 1 the individual will be alive with a probability of exp(-0.001) > 0.99. But here is the output with pomp version 1.12:

```
     N sim  time
 1   0   1 0e+00
 101 0   1 1e+00
 201 0   1 1e+06
 2   0   2 0e+00
 102 0   2 1e+00
 202 0   2 1e+06
 3   0   3 0e+00
 103 0   3 1e+00
 203 0   3 1e+06
 4   0   4 0e+00
 104 0   4 1e+00
 204 0   4 1e+06
 5   0   5 0e+00
 105 0   5 1e+00
 205 0   5 1e+06
[...]
```
where I've snipped off the other 95 replicates which also have zero for all times. Looking at the code, it seemed to me that the observations were being set to the state of the system after the next jump. I made some changes that seem to correct the problem, although probably not in an optimal manner with respect to speed. My goal in this pull request is primarily to provide a detailed description what appears to be a bug to me. With the changes, I get the following output from the above code:

```
     N sim  time
 1   1   1 0e+00
 101 1   1 1e+00
 201 0   1 1e+06
 2   1   2 0e+00
 102 1   2 1e+00
 202 0   2 1e+06
 3   1   3 0e+00
 103 1   3 1e+00
 203 0   3 1e+06
 4   1   4 0e+00
 104 1   4 1e+00
 204 0   4 1e+06
 5   1   5 0e+00
 105 1   5 1e+00
 205 0   5 1e+06
[...]
 ```

This output matches my expectations. It is important to me that the simulator is accurate because I maintain an R package that makes use of it, and I also use it in my own work. So even if I'm out to lunch about something here, please let me know so I don't worry about it.