### PR TITLE
Update potential observation following each jump

### DIFF
--- a/src/ssa.c
+++ b/src/ssa.c
@@ -165,18 +165,18 @@ static void SSA (pomp_ssa_rate_fn *ratefun, int irep,
     }
 
     // Record output at required time points
-    if (t >= times[icount]) {
-      while ((icount < ntimes) && (t >= times[icount])) {
-        memcpy(xout+nvar*(irep+nrep*icount),y,nvar*sizeof(double));
-        // Set appropriate states to zero at time of last observation
-        for (i = 0; i < nzero; i++) y[izero[i]] = 0;
-        // Recompute if zero event-rate encountered
-        if (flag) t = times[icount];
-        icount++;
+    while ((icount < ntimes) && (t >= times[icount])) {
+      memcpy(xout+nvar*(irep+nrep*icount),y,nvar*sizeof(double));
+      // Set appropriate states to zero at time of last observation
+      for (i = 0; i < nzero; i++) {
+	ynext[izero[i]] -= y[izero[i]];
+	y[izero[i]] = 0;
       }
-      memcpy(y,ynext,nvar*sizeof(double));
-      for (i = 0; i < nzero; i++) ynext[izero[i]] = 0;
+      // Recompute if zero event-rate encountered
+      if (flag) t = times[icount];
+      icount++;
     }
+    memcpy(y,ynext,nvar*sizeof(double));
 
     if ((mcov > 0) && (t <= tmax)) table_lookup(&tab,t,covars);
 


### PR DESCRIPTION
@kingaa, thanks for the rapid response to #42, as well as the personal acknowledgment for finding the bug. I think the fix is not quite done yet though. I noticed the Gillespie simulator was producing unexpected results in the case that the observation times were widely spaced. Here's a simple example using one of the pomp objects in tests/dp.R:

```r
create_example <- function(times = 1, t0 = 0, mu = 0.001, N_0 = 1,
                           simulator = c("gillespie","kleap","euler","onestep")) {
    data <- data.frame(time = times, reports = NA)
    d <- cbind(death = c(1,0))
    v <- cbind(death = c(-1,1))
    e <- c(0.03,0)
    f <- function(j, x, t, params, ...){
        params["mu"] * x[1]
    }
    simulator <- match.arg(simulator)
    switch(
        simulator,
        gillespie=gillespie.sim(rate.fun = f, v = v, d = d),
        kleap=kleap.sim(rate.fun = f, v = v, d = d, e = e),
        euler=euler.sim(
            Csnippet("double x = rbinom(N,1-exp(-mu*dt)); N -= x; ct += x;"),
            delta.t=0.1
        ),
        onestep=onestep.sim(
            Csnippet("double x = rbinom(N,1-exp(-mu*dt)); N -= x; ct += x;")
        )
    ) -> rprocess
    initializer <- function(params, t0, ...) {
        c(N=N_0,ct=12)
    }
    pomp(data = data, times = "time", t0 = t0, params = c(mu=mu),
         rprocess = rprocess, initializer = initializer, zeronames="ct",
         paramnames=c("mu"), statenames=c("N","ct"))
}

ex <- create_example()
pomp::simulate(ex, as.data.frame=TRUE, states=TRUE, times = c(1e6), nsim = 100)

```

With pomp 1.13, I get
```
    N ct sim  time
1   1  0   1 1e+06
2   1  0   2 1e+06
3   1  0   3 1e+06
4   1  0   4 1e+06
5   1  0   5 1e+06
6   1  0   6 1e+06
7   1  0   7 1e+06
8   1  0   8 1e+06
9   1  0   9 1e+06
10  1  0  10 1e+06
[...]
```
All 100 simulations have no deaths occurring before time 1e6, whereas the expected probability of surviving to this time is exp(-1000). It seems to me that this behavior results from the y variable in the SSA function not being updated after every jump. With the changes in this pull request, I get the saner output of
```
    N ct sim  time
1   0  1   1 1e+06
2   0  1   2 1e+06
3   0  1   3 1e+06
4   0  1   4 1e+06
5   0  1   5 1e+06
6   0  1   6 1e+06
7   0  1   7 1e+06
8   0  1   8 1e+06
9   0  1   9 1e+06
10  0  1  10 1e+06
[...]
```

Again, the changes are not intended to be optimal but are hopefully of some use for understanding the problem. I really like the simulator's interface and simply want to do my part to ensure that the output is accurate so I can continue using it with confidence.
