### PR TITLE
fixed typo in pomp plot method

### DIFF
--- a/R/plot_pomp.R
+++ b/R/plot_pomp.R
@@ -106,7 +106,7 @@ plotpomp.internal <- function (x, y,
              ...
              )
     v1 <- v2+1
-    v2 <- min(v2+plots.per.page-1,length(vars))    
+    v2 <- min(v1+plots.per.page-1,length(vars))    
   }
   invisible(NULL)
 }


### PR DESCRIPTION
Fixes a bug in plotpomp that becomes evident if you have 20 observation variables