### PR TITLE
fixed candidate.dist parameter in sannbox.R

### DIFF
--- a/R/sannbox.R
+++ b/R/sannbox.R
@@ -54,6 +54,12 @@ sannbox <- function (par, fn, control = list(), ...) {
 
     if (is.null(control$candidate.dist))
         candidate.dist <- function (par, temp, scale) rnorm(n=npar,mean=par,sd=scale*temp)
+    else if (!is.null(control$candidate.dist) &&
+             is.function(control$candidate.dist))
+        candidate.dist <- control$candidate.dist
+    else
+        stop(ep, sQuote("control$candidate.dist"), " must be a function",
+             call.=FALSE)
 
     if (length(control$lower)<npar)
         control$lower <- rep(control$lower,npar)


### PR DESCRIPTION
Passing candidate.dist using the control list did not work, since in the case control$candidate.dist was not NULL, it was never assigned in the function's namespace. This commit fixes the issue and adds a check requiring that candidate.dist is a function, if any is passed.