### PR TITLE
Minor change to simulate function with format = data.frame, and inclu…

### DIFF
--- a/R/simulate.R
+++ b/R/simulate.R
@@ -22,7 +22,7 @@
 ##' if set, the pseudorandom number generator (RNG) will be initialized with \code{seed}.  the random seed to use.
 ##' The RNG will be restored to its original state afterward.
 ##' @param format the format in which to return the results.
-##' 
+##'
 ##' \code{format = "pomps"} causes the results to be returned as a single \dQuote{pomp} object,
 ##' identical to \code{object} except for the latent states and observations,
 ##' which have been replaced by the simulated values.
@@ -234,7 +234,7 @@ simulate.internal <- function (
       dat$.id <- "data"
       allnm <- union(names(dat),names(sims))
       for (n in setdiff(allnm,names(dat))) dat[[n]] <- NA
-      for (n in setdiff(allnm,names(sims))) sims[[n]] <- dat[[n]]
+      for (n in setdiff(allnm,names(sims))) sims[[n]] <- rep(dat[[n]], each = nsim)
       sims <- rbind(dat,sims)
       sims$.id <- ordered(sims$.id,levels=c("data",simnames))
     } else {


### PR DESCRIPTION
…de.data = TRUE. The change fixes a bug so that the covariates in the resulting simulation data.frame match the covariates in the actual data. Ed Ionides helped me snuff-out this minor bug.

The bug occurred because the simulations are ordered in the data.frame object by the time point rather than the simulation number, but the code assumes that the simulations are sorted by simulation number (see example below). 

Let nsim = 2, and let simx-t represent the t-th time point of the x-th simulation. Similarly, let data-t be the covariate at the t-th time point. Then the suggested change is:

What was happening: 
sim1-1 = data-1
sim2-1 = data-2
sim1-2 = data-3
sim2-2 = data-4
sim1-3 = data-5
...


What should happen: 
sim1-1 = data-1
sim2-1 = data-1
sim1-2 = data-2
sim2-2 = data-2
sim1-3 = data-3
...
